### PR TITLE
fix(deploy): update vercel configuration for pnpm workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "ai-engineer-challenge",
 	"private": true,
+	"packageManager": "pnpm@10.11.0",
 	"scripts": {
 		"lint:md": "markdownlint \"**/*.md\"",
 		"lint:md:fix": "markdownlint --fix \"**/*.md\"",
@@ -11,6 +12,5 @@
 	},
 	"devDependencies": {
 		"markdownlint-cli": "^0.45.0"
-	},
-	"packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
+	}
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "version": 2,
-  "installCommand": "pnpm install",
   "builds": [
     { "src": "frontend/package.json", "use": "@vercel/next" },
     { "src": "api/app.py", "use": "@vercel/python" }


### PR DESCRIPTION
Fixed Vercel deployment configuration to properly work with pnpm workspace setup by simplifying package manager specification and removing redundant install commands.

---

## Details

- **Simplified packageManager field**: Removed the lengthy SHA hash from `packageManager` in `package.json`, keeping only the clean version specification `pnpm@10.11.0`
- **Removed redundant installCommand**: Deleted `"installCommand": "pnpm install"` from `vercel.json` since Vercel automatically detects and uses pnpm when `packageManager` is specified
- **Cleaner configuration**: This follows Vercel's best practices for pnpm workspace deployments where explicit install commands are unnecessary

The changes build upon the initial Vercel deployment setup (PR #5) which added:
- Complete `vercel.json` configuration for Next.js frontend and Python API
- Build and deploy scripts in `package.json`
- Workspace-level dependency management
- Cleaned up frontend-specific lock files

---

## Checklist

- [x] All changes are committed and documented
- [x] Only a single feature or fix is addressed in this PR
- [x] Code and documentation changes are thoroughly explained
- [x] No unrelated changes are included

---

## Notes

This fix addresses potential deployment issues where Vercel might have conflicts between the explicit `installCommand` and the auto-detected pnpm workspace setup. The simplified configuration should result in more reliable deployments.
