### PR TITLE
fix(deploy): resolve pnpm workspace deployment issues

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,5 +43,5 @@
     "tw-animate-css": "^1.3.4",
     "typescript": "^5"
   },
-  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
+  "packageManager": "pnpm@10.11.0"
 }

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,4 +1,0 @@
-onlyBuiltDependencies:
-  - '@biomejs/biome'
-  - '@tailwindcss/oxide'
-  - sharp

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,11 @@
 packages:
-  - frontend
-  - api
+  - "frontend"
+  - "api"
+
 onlyBuiltDependencies:
   - "@biomejs/biome"
   - "@tailwindcss/postcss"
+  - "@tailwindcss/oxide"
   - "tailwindcss"
   - "typescript"
   - "sharp"

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
+  "installCommand": "corepack enable && corepack prepare pnpm@10.11.0 --activate && pnpm install",
   "builds": [
     { "src": "frontend/package.json", "use": "@vercel/next" },
     { "src": "api/app.py", "use": "@vercel/python" }


### PR DESCRIPTION
Fixed critical Vercel deployment failures caused by conflicting pnpm workspace configurations and version mismatches. The deployment was failing with "packages field missing or empty" error due to workspace setup conflicts.

---

## Details

- **Removed conflicting workspace file**: Deleted `frontend/pnpm-workspace.yaml` that was conflicting with the root workspace configuration
- **Added explicit install command**: Updated `vercel.json` with `corepack enable && corepack prepare pnpm@10.11.0 --activate && pnpm install` to force pnpm@10.x usage (Vercel was defaulting to pnpm@9.x)
- **Cleaned up packageManager field**: Simplified `packageManager` in `frontend/package.json` by removing the lengthy SHA hash, keeping only `pnpm@10.11.0`
- **Enhanced workspace configuration**: Updated root `pnpm-workspace.yaml` with proper quotes and added missing `@tailwindcss/oxide` dependency

**Root cause**: Vercel was detecting pnpm@9.x based on project creation date and the conflicting workspace files were causing the "packages field missing or empty" error during installation.

**Solution approach**: Force pnpm@10.x via corepack and eliminate workspace configuration conflicts by maintaining a single source of truth at the root level.

---

## Checklist

- [x] All changes are committed and documented
- [x] Only a single feature or fix is addressed in this PR
- [x] Code and documentation changes are thoroughly explained
- [x] No unrelated changes are included

---

## Notes (optional)

- **Testing**: Local `pnpm install` and `pnpm build` both work successfully after these changes
- **Deployment impact**: This should resolve the persistent Vercel deployment failures
- **Workspace integrity**: Maintains proper monorepo structure with frontend and api packages
