### PR TITLE
fix(ui): remove quotes from Tailwind bg-url syntax

### DIFF
--- a/frontend/src/components/layout/animated-background.tsx
+++ b/frontend/src/components/layout/animated-background.tsx
@@ -33,12 +33,12 @@ export function AnimatedBackground({ children }: { children: React.ReactNode }) 
       <div className="absolute inset-0 origin-center [transform:scale(2.5)] bg-gradient-to-bl from-[#0f172a] via-[#1e1a78] to-[#0f172a]">
         {/* Gray logo pattern - shown when API key is invalid */}
         <div
-          className={`absolute inset-0 bg-[url('/assets/logos/aimakerspace-gray-192.png')] bg-[length:192px_192px] bg-center bg-repeat transition-opacity duration-300 ease-in-out ${logoState === 'invalid' ? 'opacity-100' : 'opacity-0'}`}
+          className={`absolute inset-0 bg-[url(/assets/logos/aimakerspace-gray-192.png)] bg-[length:192px_192px] bg-center bg-repeat transition-opacity duration-300 ease-in-out ${logoState === 'invalid' ? 'opacity-100' : 'opacity-0'}`}
         />
 
         {/* Yellow logo pattern - shown when API key is valid */}
         <div
-          className={`absolute inset-0 bg-[url('/assets/logos/aimakerspace-i-192.png')] bg-[length:192px_192px] bg-center bg-repeat transition-opacity duration-300 ease-in-out ${logoState === 'valid' ? 'opacity-100' : 'opacity-0'}`}
+          className={`absolute inset-0 bg-[url(/assets/logos/aimakerspace-i-192.png)] bg-[length:192px_192px] bg-center bg-repeat transition-opacity duration-300 ease-in-out ${logoState === 'valid' ? 'opacity-100' : 'opacity-0'}`}
         />
 
         {/* Glassmorphism overlay */}


### PR DESCRIPTION
Fixed webpack module resolution error by removing quotes around URL paths in Tailwind CSS bg-[url(...)] arbitrary values in the AnimatedBackground component.

## Details

- Removed quotes from `/assets/logos/aimakerspace-gray-192.png` and `/assets/logos/aimakerspace-i-192.png` URLs in bg-[url(...)] classes
- Tailwind CSS arbitrary values don't require quotes around URL paths, and including them caused webpack to incorrectly try to resolve the path as a module import
- Fixed build error: "Module not found: Can't resolve './'/assets/logos/aimakerspace-gray-192.png'"
- Maintains all existing functionality and styling while resolving the compilation issue

## Checklist

- [x] All changes are committed and documented
- [x] Only a single feature or fix is addressed in this PR
- [x] Code and documentation changes are thoroughly explained
- [x] No unrelated changes are included

## Notes

Verified that the Tailwind CSS documentation confirms bg-[url(...)] syntax should not include quotes around the URL path. The error was specifically caused by webpack trying to resolve the quoted path as a module instead of treating it as a static asset URL.